### PR TITLE
Implemented access to data from mainContainer component

### DIFF
--- a/react_app/package-lock.json
+++ b/react_app/package-lock.json
@@ -3493,6 +3493,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
     },
+    "axios": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -9893,6 +9915,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/react_app/package.json
+++ b/react_app/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/react_app/src/components/mainContainer.js
+++ b/react_app/src/components/mainContainer.js
@@ -1,7 +1,19 @@
+import { useState, useEffect } from 'react';
 import MapContainer from "./mapContainer";
 import ResultsContainer from "./resultsContainer";
+import serviceFunctions from '../services/data';
 
 const MainContainer = () => {
+  const [springsData, setSpringData] = useState([]);
+
+  useEffect(() => {
+    serviceFunctions.getAll()
+    .then(springsArr => {
+      console.log(springsArr);        // for testing purpose, remove later 
+      setSpringData(springsArr);
+    });
+  }, []);
+
   return (
     <>
       <div className="flex">
@@ -9,7 +21,7 @@ const MainContainer = () => {
           <MapContainer />
         </div>
         <div className="w-2/5 bg-gray-300 p-6">
-          <ResultsContainer />
+          <ResultsContainer data={springsData}/>
         </div>
       </div>
     </>

--- a/react_app/src/components/resultsContainer.js
+++ b/react_app/src/components/resultsContainer.js
@@ -1,13 +1,12 @@
-import sample_data from '../lib/sample_data.json';
 import SingleSpring from "./singleSpring";
 
-const ResultsContainer = () => {
+const ResultsContainer = ({ data }) => {
   return (
     <>
       <h2 className="text-lg font-bold mb-4 text-center">
-        {sample_data.length} results found
+        {data.length} results found
       </h2>
-      {sample_data.map(spring => 
+      {data.map(spring => 
         <SingleSpring 
           key={spring._id}
           spring={spring}

--- a/react_app/src/services/data.js
+++ b/react_app/src/services/data.js
@@ -1,7 +1,8 @@
 import axios from "axios";
+const baseUrl = "https://hot-springs-api.herokuapp.com/all"
 
 const getAll = () => {
-  const request = axios.get("https://hot-springs-api.herokuapp.com/all");
+  const request = axios.get(baseUrl);
   return request.then((response) => response.data);
 };
 
@@ -40,4 +41,6 @@ const convertToGeoJSON = (data) => {
   return geoJSON;
 };
 
-export default { getAll, convertToGeoJSON };
+const serviceFunctions = { getAll, convertToGeoJSON }
+
+export default serviceFunctions;


### PR DESCRIPTION
In `mainContainer` I used the `useEffect` hook to fetch the data from the DB via the service `getAll` function, and the `useState` to assign the returned data to the variable `springsData`. That var can now be passed as prop (i.e arguments in React) to the component that require it; in my case I used it to feed data to `ResultsContainer`. The current listing in the app is now real data from the db and not fake data anymore!

You can follow the same patter to feed the data you require (GEOJson??) to the `MapContainer` from `mainContainer`.

Note that I decided to implement this functionality in the `mainContainer` component, instead of in the `App` component, bc `mainContainer` is the component that subdivides into the two components that require the data (results and map). The top menu and the footer don't require data from DB.