### PR TITLE
fetching data from db and feeding components within mainContainer

### DIFF
--- a/react_app/src/components/mainContainer.js
+++ b/react_app/src/components/mainContainer.js
@@ -1,7 +1,19 @@
+import { useState, useEffect } from 'react';
 import MapContainer from "./mapContainer";
 import ResultsContainer from "./resultsContainer";
+import serviceFunctions from '../services/data';
 
 const MainContainer = () => {
+  const [springsData, setSpringData] = useState([]);
+
+  useEffect(() => {
+    serviceFunctions.getAll()
+    .then(springsArr => {
+      console.log(springsArr);        // for testing purpose, remove later 
+      setSpringData(springsArr);
+    });
+  }, []);
+
   return (
     <>
       <div className="flex">
@@ -9,7 +21,7 @@ const MainContainer = () => {
           <MapContainer />
         </div>
         <div className="w-2/5 bg-gray-300 p-6">
-          <ResultsContainer />
+          <ResultsContainer data={springsData}/>
         </div>
       </div>
     </>

--- a/react_app/src/components/resultsContainer.js
+++ b/react_app/src/components/resultsContainer.js
@@ -1,13 +1,12 @@
-import sample_data from '../lib/sample_data.json';
 import SingleSpring from "./singleSpring";
 
-const ResultsContainer = () => {
+const ResultsContainer = ({ data }) => {
   return (
     <>
       <h2 className="text-lg font-bold mb-4 text-center">
-        {sample_data.length} results found
+        {data.length} results found
       </h2>
-      {sample_data.map(spring => 
+      {data.map(spring => 
         <SingleSpring 
           key={spring._id}
           spring={spring}

--- a/react_app/src/services/data.js
+++ b/react_app/src/services/data.js
@@ -1,8 +1,9 @@
 import axios from "axios";
+const baseUrl = "https://hot-springs-api.herokuapp.com/all"
 
 const getAll = async () => {
   try {
-    const response = await axios.get("https://hot-springs-api.herokuapp.com/all");
+    const response = await axios.get(baseUrl);
     const data = await response.data;
     return data;
   } catch (e) {
@@ -45,4 +46,6 @@ const convertToGeoJSON = (data) => {
   return geoJSON;
 };
 
-export default { getAll, convertToGeoJSON };
+const serviceFunctions = { getAll, convertToGeoJSON }
+
+export default serviceFunctions;


### PR DESCRIPTION
In `mainContainer` I used the `useEffect` hook to fetch the data from the DB via the service `getAll` function, and the `useState` to assign the returned data to the variable `springsData`. That var can now be passed as prop (i.e arguments in React) to the component that require it; in my case I used it to feed data to `ResultsContainer`. The current listing in the app is now real data from the db and not fake data anymore!

You can follow the same patter to feed the data you require (GEOJson??) to the `MapContainer` from `mainContainer`.

Note that I decided to implement this functionality in the `mainContainer` component, instead of in the `App` component, bc that is the component that contains the two components that require the data (results and map). The top menu and the footer don't require data from DB.